### PR TITLE
100% (line) coverage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Asynchronously adds an array of block instances to the underlying repo.
 Asynchronously returns the block whose content multihash matches `multihash`.
 Returns an error (`err.code === 'ENOENT'`) if the block does not exist.
 
+If the block could not be found, expect `err.code` to be `'ENOENT'`.
+
 #### bs.getBlocks(multihashes, callback(err, blocks))
 
 Asynchronously returns the blocks whose content multihashes match the array

--- a/README.md
+++ b/README.md
@@ -157,7 +157,18 @@ If the block could not be found, expect `err.code` to be `'ENOENT'`.
 
 Asynchronously returns the blocks whose content multihashes match the array
 `multihashes`.
-Returns an error (`err.code === 'ENOENT'`) if *any* the blocks do not exist.
+
+`blocks` is an object that maps each `multihash` to an object of the form
+
+```js
+{
+  err: Error
+  block: Block
+}
+```
+
+Expect `blocks[multihash].err.code === 'ENOENT'`  and `blocks[multihash].block
+=== null` if a block did not exist.
 
 *Does not guarantee atomicity.*
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,13 @@ Asynchronously adds an array of block instances to the underlying repo.
 #### bs.getBlock(multihash, callback(err, block))
 
 Asynchronously returns the block whose content multihash matches `multihash`.
+Returns an error (`err.code === 'ENOENT'`) if the block does not exist.
 
 #### bs.getBlocks(multihashes, callback(err, blocks))
 
 Asynchronously returns the blocks whose content multihashes match the array
 `multihashes`.
+Returns an error (`err.code === 'ENOENT'`) if *any* the blocks do not exist.
 
 *Does not guarantee atomicity.*
 

--- a/src/block-service.js
+++ b/src/block-service.js
@@ -85,7 +85,7 @@ function BlockService (ipfsRepo, exchange) {
     }
 
     if (!Array.isArray(multihashes)) {
-      return callback('Invalid batch of multihashes')
+      return callback(new Error('Invalid batch of multihashes'))
     }
 
     async.each(multihashes, (multihash, next) => {

--- a/src/block-service.js
+++ b/src/block-service.js
@@ -52,18 +52,18 @@ function BlockService (ipfsRepo, exchange) {
       return callback(new Error('Invalid batch of multihashes'))
     }
 
-    const blocks = []
+    var results = {}
 
     async.each(multihashes, (multihash, next) => {
       this.getBlock(multihash, extension, (err, block) => {
-        if (err) { return next(err) }
-        if (block) {
-          blocks.push(block)
+        results[multihash] = {
+          err: err,
+          block: block
         }
         next()
       })
     }, (err) => {
-      callback(err, blocks)
+      callback(err, results)
     })
   }
 

--- a/src/block-service.js
+++ b/src/block-service.js
@@ -26,13 +26,13 @@ function BlockService (ipfsRepo, exchange) {
   }
 
   this.getBlock = (multihash, extension, callback) => {
-    if (!multihash) {
-      return callback(new Error('Invalid multihash'))
-    }
-
     if (typeof extension === 'function') {
       callback = extension
       extension = undefined
+    }
+
+    if (!multihash) {
+      return callback(new Error('Invalid multihash'))
     }
 
     ipfsRepo.datastore.createReadStream(multihash, extension)
@@ -43,13 +43,13 @@ function BlockService (ipfsRepo, exchange) {
   }
 
   this.getBlocks = (multihashes, extension, callback) => {
-    if (!Array.isArray(multihashes)) {
-      return callback(new Error('Invalid batch of multihashes'))
-    }
-
     if (typeof extension === 'function') {
       callback = extension
       extension = undefined
+    }
+
+    if (!Array.isArray(multihashes)) {
+      return callback(new Error('Invalid batch of multihashes'))
     }
 
     const blocks = []
@@ -65,26 +65,26 @@ function BlockService (ipfsRepo, exchange) {
   }
 
   this.deleteBlock = (multihash, extension, callback) => {
-    if (!multihash) {
-      return callback(new Error('Invalid multihash'))
-    }
-
     if (typeof extension === 'function') {
       callback = extension
       extension = undefined
+    }
+
+    if (!multihash) {
+      return callback(new Error('Invalid multihash'))
     }
 
     ipfsRepo.datastore.remove(multihash, extension, callback)
   }
 
   this.deleteBlocks = (multihashes, extension, callback) => {
-    if (!Array.isArray(multihashes)) {
-      return callback('Invalid batch of multihashes')
-    }
-
     if (typeof extension === 'function') {
       callback = extension
       extension = undefined
+    }
+
+    if (!Array.isArray(multihashes)) {
+      return callback('Invalid batch of multihashes')
     }
 
     async.each(multihashes, (multihash, next) => {

--- a/src/block-service.js
+++ b/src/block-service.js
@@ -35,19 +35,11 @@ function BlockService (ipfsRepo, exchange) {
       return callback(new Error('Invalid multihash'))
     }
 
-    ipfsRepo.datastore.exists(multihash, (err, exists) => {
-      if (err) { return callback(err) }
-
-      if (exists) {
-        ipfsRepo.datastore.createReadStream(multihash, extension)
-          .pipe(bl((err, data) => {
-            if (err) { return callback(err) }
-            callback(null, new Block(data, extension))
-          }))
-      } else {
-        callback(null, null)
-      }
-    })
+    ipfsRepo.datastore.createReadStream(multihash, extension)
+      .pipe(bl((err, data) => {
+        if (err) { return callback(err) }
+        callback(null, new Block(data, extension))
+      }))
   }
 
   this.getBlocks = (multihashes, extension, callback) => {

--- a/src/block-service.js
+++ b/src/block-service.js
@@ -58,6 +58,7 @@ function BlockService (ipfsRepo, exchange) {
       this.getBlock(multihash, extension, (err, block) => {
         if (err) { return next(err) }
         blocks.push(block)
+        next()
       })
     }, (err) => {
       callback(err, blocks)

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -15,7 +15,7 @@ module.exports = (repo) => {
       done()
     })
 
-    it('store a block', (done) => {
+    it('store and get a block', (done) => {
       const b = new Block('A random data block')
       bs.addBlock(b, (err) => {
         expect(err).to.not.exist
@@ -28,7 +28,7 @@ module.exports = (repo) => {
       })
     })
 
-    it('store a block, with custom extension', (done) => {
+    it('store and get a block, with custom extension', (done) => {
       const b = new Block('A random data block', 'ext')
       bs.addBlock(b, (err) => {
         expect(err).to.not.exist
@@ -44,7 +44,8 @@ module.exports = (repo) => {
     it('get a non existent block', (done) => {
       const b = new Block('Not stored')
       bs.getBlock(b.key, (err, block) => {
-        expect(err).to.exist
+        expect(err).to.not.exist
+        expect(block).to.not.exist
         done()
       })
     })
@@ -60,6 +61,61 @@ module.exports = (repo) => {
       })
     })
 
+    it('addBlocks: bad invocation', (done) => {
+      const b1 = new Block('1')
+
+      bs.addBlocks(b1, (err) => {
+        expect(err).to.be.an('error')
+        done()
+      })
+    })
+
+    it('getBlock: bad invocation', (done) => {
+      bs.getBlock(null, (err) => {
+        expect(err).to.be.an('error')
+        done()
+      })
+    })
+
+    it('getBlocks: bad invocation', (done) => {
+      bs.getBlocks(null, 'protobuf', (err) => {
+        expect(err).to.be.an('error')
+        done()
+      })
+    })
+
+    it('get many blocks', (done) => {
+      const b1 = new Block('1')
+      const b2 = new Block('2')
+      const b3 = new Block('3')
+
+      bs.addBlocks([b1, b2, b3], (err) => {
+        expect(err).to.not.exist
+
+        bs.getBlocks([b1.key, b2.key, b3.key], (err, blocks) => {
+          expect(err).to.not.exist
+          expect(blocks).to.have.lengthOf(3)
+          done()
+        })
+      })
+    })
+
+    it('get many blocks: partial success', (done) => {
+      const b1 = new Block('a1')
+      const b2 = new Block('a2')
+      const b3 = new Block('a3')
+
+      bs.addBlocks([b1, b3], (err) => {
+        expect(err).to.not.exist
+
+        bs.getBlocks([b1.key, b2.key, b3.key], (err, blocks) => {
+          expect(err).to.not.exist
+          expect(blocks).to.have.lengthOf(2)
+          done()
+        })
+      })
+    })
+
     it('delete a block', (done) => {
       const b = new Block('Will not live that much')
       bs.addBlock(b, (err) => {
@@ -67,10 +123,18 @@ module.exports = (repo) => {
         bs.deleteBlock(b.key, (err) => {
           expect(err).to.not.exist
           bs.getBlock(b.key, (err, block) => {
-            expect(err).to.exist
+            expect(err).to.not.exist
+            expect(block).to.not.exist
             done()
           })
         })
+      })
+    })
+
+    it('deleteBlock: bad invocation', (done) => {
+      bs.deleteBlock(null, (err) => {
+        expect(err).to.be.an('error')
+        done()
       })
     })
 
@@ -81,7 +145,8 @@ module.exports = (repo) => {
         bs.deleteBlock(b.key, 'ext', (err) => {
           expect(err).to.not.exist
           bs.getBlock(b.key, 'ext', (err, block) => {
-            expect(err).to.exist
+            expect(err).to.not.exist
+            expect(block).to.not.exist
             done()
           })
         })
@@ -101,8 +166,15 @@ module.exports = (repo) => {
       const b2 = new Block('2')
       const b3 = new Block('3')
 
-      bs.deleteBlocks([b1, b2, b3], (err) => {
+      bs.deleteBlocks([b1, b2, b3], 'data', (err) => {
         expect(err).to.not.exist
+        done()
+      })
+    })
+
+    it('deleteBlocks: bad invocation', (done) => {
+      bs.deleteBlocks(null, (err) => {
+        expect(err).to.be.an('error')
         done()
       })
     })

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -44,8 +44,7 @@ module.exports = (repo) => {
     it('get a non existent block', (done) => {
       const b = new Block('Not stored')
       bs.getBlock(b.key, (err, block) => {
-        expect(err).to.not.exist
-        expect(block).to.not.exist
+        expect(err).to.exist
         done()
       })
     })
@@ -109,8 +108,8 @@ module.exports = (repo) => {
         expect(err).to.not.exist
 
         bs.getBlocks([b1.key, b2.key, b3.key], (err, blocks) => {
-          expect(err).to.not.exist
-          expect(blocks).to.have.lengthOf(2)
+          expect(err).to.exist
+          expect(blocks).to.have.lengthOf(0)
           done()
         })
       })
@@ -123,8 +122,7 @@ module.exports = (repo) => {
         bs.deleteBlock(b.key, (err) => {
           expect(err).to.not.exist
           bs.getBlock(b.key, (err, block) => {
-            expect(err).to.not.exist
-            expect(block).to.not.exist
+            expect(err).to.exist
             done()
           })
         })
@@ -145,8 +143,7 @@ module.exports = (repo) => {
         bs.deleteBlock(b.key, 'ext', (err) => {
           expect(err).to.not.exist
           bs.getBlock(b.key, 'ext', (err, block) => {
-            expect(err).to.not.exist
-            expect(block).to.not.exist
+            expect(err).to.exist
             done()
           })
         })

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -109,7 +109,7 @@ module.exports = (repo) => {
 
         bs.getBlocks([b1.key, b2.key, b3.key], (err, blocks) => {
           expect(err).to.exist
-          expect(blocks).to.have.lengthOf(0)
+          expect(blocks).to.have.length.below(3)
           done()
         })
       })

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -93,7 +93,16 @@ module.exports = (repo) => {
 
         bs.getBlocks([b1.key, b2.key, b3.key], (err, blocks) => {
           expect(err).to.not.exist
-          expect(blocks).to.have.lengthOf(3)
+          expect(Object.keys(blocks)).to.have.lengthOf(3)
+          expect(blocks[b1.key]).to.exist
+          expect(blocks[b1.key].err).to.not.exist
+          expect(blocks[b1.key].block.data).to.deep.equal(b1.data)
+          expect(blocks[b2.key]).to.exist
+          expect(blocks[b2.key].err).to.not.exist
+          expect(blocks[b2.key].block.data).to.deep.equal(b2.data)
+          expect(blocks[b3.key]).to.exist
+          expect(blocks[b3.key].err).to.not.exist
+          expect(blocks[b3.key].block.data).to.deep.equal(b3.data)
           done()
         })
       })
@@ -108,8 +117,17 @@ module.exports = (repo) => {
         expect(err).to.not.exist
 
         bs.getBlocks([b1.key, b2.key, b3.key], (err, blocks) => {
-          expect(err).to.exist
-          expect(blocks).to.have.length.below(3)
+          expect(err).to.not.exist
+          expect(Object.keys(blocks)).to.have.lengthOf(3)
+          expect(blocks[b1.key]).to.exist
+          expect(blocks[b1.key].err).to.not.exist
+          expect(blocks[b1.key].block.data).to.deep.equal(b1.data)
+          expect(blocks[b2.key]).to.exist
+          expect(blocks[b2.key].err).to.exist
+          expect(blocks[b2.key].block).to.not.exist
+          expect(blocks[b3.key]).to.exist
+          expect(blocks[b3.key].err).to.not.exist
+          expect(blocks[b3.key].block.data).to.deep.equal(b3.data)
           done()
         })
       })

--- a/test/block.spec.js
+++ b/test/block.spec.js
@@ -12,6 +12,13 @@ describe('block', () => {
     expect(b.extension).to.be.eql('data')
   })
 
+  it('create /wo new', () => {
+    const b = Block('random-data')
+    expect(b.key).to.exist
+    expect(b.data).to.exist
+    expect(b.extension).to.be.eql('data')
+  })
+
   it('fail to create an empty block', () => {
     expect(() => new Block()).to.throw()
   })


### PR DESCRIPTION
Woohoo! This PR contains both important bugfixes and also test cases that prove their newfound correctness!

Important: this also changes the `getBlock()` callback semantics to _NOT_ populate `err` when a block cannot be found. It is this hacker's belief that "not found" is not an error case. The README is also updated to reflect this!

This gets us to 100% line coverage. There are a few tiny branches still not covered, but they are both a) trivial, and b) would require test case bloat / noise to cover them.

Addresses https://github.com/ipfs/js-ipfs/issues/115.
