### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 └─────────┘ └───────┘
 ```
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipfs-block-service",
   "version": "0.14.0",
   "description": "JavaScript Implementation of BlockService",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "lint": "aegir lint",
@@ -26,10 +27,6 @@
   },
   "keywords": [
     "IPFS"
-  ],
-  "authors": [
-    "David Dias <daviddias@ipfs.io>",
-    "Vijayee Kulkaa <vijayee.kulkaa@hushmail.com"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md

Closes #77.