### PR TITLE
chore: change 'async' module from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/ipfs/js-ipfs-block-service#readme",
   "devDependencies": {
     "aegir": "^17.0.0",
-    "async": "^2.6.1",
     "chai": "^4.2.0",
     "cids": "~0.5.5",
     "dirty-chai": "^2.0.1",
@@ -46,7 +45,9 @@
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "async": "^2.6.1"
+  },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",
     "Friedel Ziegelmayer <dignifiedquire@gmail.com>",


### PR DESCRIPTION
The aim of this PR is to change [async](https://github.com/caolan/async) module from `devDependencies` to `dependencies` as it's being required [here](https://github.com/ipfs/js-ipfs-block-service/blob/master/src/index.js#L3). 

I'm using a project where [async](https://github.com/caolan/async) is being installed on its `1.5.2` version and then, `ipfs-block-service` is using this version, which does not have the `async/map` implementation that is required here.