### PR TITLE
chore: callbacks -> async / await

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,31 +72,20 @@ const repo = new IPFSRepo('example')
 
 // create a block
 const data = new Buffer('hello world')
-multihashing(data, 'sha2-256', (err, multihash) => {
-  if (err) {
-    throw err
-  }
+const multihash = await multihashing(data, 'sha2-256')
 
-  const cid = new CID(multihash)
-  const block = new Block(data, cid)
+const cid = new CID(multihash)
+const block = new Block(data, cid)
 
-  // create a service
-  const bs = new BlockService(repo)
+// create a service
+const service = new BlockService(repo)
 
-  // add the block, then retrieve it
-  bs.put(block, (err) => {
-    if (err) {
-      throw err
-    }
-    bs.get(cid, (err, b) => {
-      if (err) {
-        throw err
-      }
-      console.log(block.data.toString() === b.data.toString())
-      // => true
-    })
-  })
-})
+// add the block, then retrieve it
+await service.put(block)
+
+const result = await service.get(cid)
+console.log(block.data.toString() === result.data.toString())
+// => true
 ```
 
 ### Browser: Browserify, Webpack, other bundlers

--- a/package.json
+++ b/package.json
@@ -34,19 +34,18 @@
     "chai": "^4.2.0",
     "cids": "~0.5.7",
     "dirty-chai": "^2.0.1",
+    "fs-extra": "^8.0.1",
     "ipfs-block": "~0.8.0",
-    "ipfs-repo": "~0.26.2",
+    "ipfs-repo": "~0.27.0",
     "lodash": "^4.17.11",
-    "multihashing-async": "~0.5.2",
-    "ncp": "^2.0.0",
-    "rimraf": "^2.6.3"
+    "multihashing-async": "~0.7.0"
   },
   "engines": {
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
   "dependencies": {
-    "async": "^2.6.2"
+    "streaming-iterables": "^4.0.2"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,7 +2,6 @@
 /* global self */
 'use strict'
 
-const series = require('async/series')
 const IPFSRepo = require('ipfs-repo')
 
 const tests = require('./block-service-test')
@@ -18,23 +17,16 @@ idb.deleteDatabase('ipfs/blocks')
 describe('IPFS Repo Tests on the Browser', () => {
   const repo = new IPFSRepo('ipfs')
 
-  before((done) => {
-    series([
-      (cb) => repo.init({}, cb),
-      (cb) => repo.open(cb)
-    ], done)
+  before(async () => {
+    await repo.init({})
+    await repo.open()
   })
 
-  after((done) => {
-    series([
-      (cb) => repo.close(cb),
-      (cb) => {
-        idb.deleteDatabase('ipfs')
-        idb.deleteDatabase('ipfs/blocks')
+  after(async () => {
+    await repo.close()
 
-        cb()
-      }
-    ], done)
+    idb.deleteDatabase('ipfs')
+    idb.deleteDatabase('ipfs/blocks')
   })
 
   tests(repo)

--- a/test/node.js
+++ b/test/node.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const ncp = require('ncp').ncp
-const series = require('async/series')
-const rimraf = require('rimraf')
+const fs = require('fs-extra')
 const path = require('path')
 const IPFSRepo = require('ipfs-repo')
 
@@ -15,18 +13,14 @@ describe('IPFS Block Tests on Node.js', () => {
   const repoPath = testRepoPath + '-for-' + date
   const repo = new IPFSRepo(repoPath)
 
-  before((done) => {
-    series([
-      (cb) => ncp(testRepoPath, repoPath, cb),
-      (cb) => repo.open(cb)
-    ], done)
+  before(async () => {
+    await fs.copy(testRepoPath, repoPath)
+    await repo.open()
   })
 
-  after((done) => {
-    series([
-      (cb) => repo.close(cb),
-      (cb) => rimraf(repoPath, cb)
-    ], done)
+  after(async () => {
+    await repo.close()
+    await fs.remove(repoPath)
   })
 
   tests(repo)


### PR DESCRIPTION
BREAKING CHANGE: All places in the API that used callbacks are now replaced with async/await

Depends on
- [x] https://github.com/multiformats/js-multihashing-async/pull/37
- [x] https://github.com/ipfs/js-ipfs-repo/pull/189