### PR TITLE
fix: throw if asked to delete a block we don't have

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "npm": ">=3.0.0"
   },
   "dependencies": {
+    "err-code": "^2.0.0",
     "streaming-iterables": "^4.1.0"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -128,12 +128,12 @@ class BlockService {
    * @param {AbortSignal} [options.signal] - A signal that can be used to abort any long-lived operations that are started as a result of this operation
    * @returns {Promise}
    */
-  async delete (cid) {
+  async delete (cid, options) {
     if (!await this._repo.blocks.has(cid)) {
       throw errcode(new Error('blockstore: block not found'), 'ERR_BLOCK_NOT_FOUND')
     }
 
-    return this._repo.blocks.delete(cid)
+    return this._repo.blocks.delete(cid, options)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { map } = require('streaming-iterables')
+const errcode = require('err-code')
 
 /**
  * BlockService is a hybrid block datastore. It stores data in a local
@@ -117,7 +118,11 @@ class BlockService {
    * @param {CID} cid
    * @returns {Promise}
    */
-  delete (cid) {
+  async delete (cid) {
+    if (!await this._repo.blocks.has(cid)) {
+      throw errcode(new Error('blockstore: block not found'), 'ERR_BLOCK_NOT_FOUND')
+    }
+
     return this._repo.blocks.delete(cid)
   }
 }

--- a/test/aborting-requests.spec.js
+++ b/test/aborting-requests.spec.js
@@ -33,7 +33,8 @@ describe('aborting requests', () => {
         putMany: abortOnSignal,
         get: abortOnSignal,
         delete: abortOnSignal,
-        deleteMany: abortOnSignal
+        deleteMany: abortOnSignal,
+        has: () => true
       }
     }
     r = new BlockService(repo)

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -80,6 +80,17 @@ module.exports = (repo) => {
         expect(res).to.be.eql(false)
       })
 
+      it('does not delete a block it does not have', async () => {
+        const data = Buffer.from('Will not live that much ' + Date.now())
+        const cid = new CID(await multihashing(data, 'sha2-256'))
+
+        await bs.delete(cid)
+          .then(
+            () => expect.fail('Should have thrown'),
+            (err) => expect(err).to.have.property('code', 'ERR_BLOCK_NOT_FOUND')
+          )
+      })
+
       it('stores and gets lots of blocks', async function () {
         this.timeout(8 * 1000)
 


### PR DESCRIPTION
This is to be consistent with go-IPFS

BREAKING CHANGE:

`bs.delete(cid)` used to ignore mystery CIDs, now it throws.