### PR TITLE
chore: swap ipfs-block for ipld-block

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "cids": "^0.8.0",
     "dirty-chai": "^2.0.1",
     "fs-extra": "^9.0.0",
-    "ipfs-block": "~0.8.1",
-    "ipfs-repo": "^1.0.1",
+    "ipfs-repo": "^2.0.0",
+    "ipld-block": "^0.9.1",
     "lodash": "^4.17.11",
     "multihashing-async": "^0.8.1"
   },

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 
-const Block = require('ipfs-block')
+const Block = require('ipld-block')
 const _ = require('lodash')
 const { collect } = require('streaming-iterables')
 const CID = require('cids')


### PR DESCRIPTION
The module was rename and the renamed version is not compatible with the old version so here we update it.

These are only dev deps so not a breaking change.