### PR TITLE
feat: add deleteMany method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,19 @@
 
 ## Table of Contents
 
-- [Install](#install)
-  - [npm](#npm)
-- [Usage](#usage)
-  - [Node.js](#nodejs)
-  - [Example](#example)
-  - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
-  - [Browser: `<script>` Tag](#browser-script-tag)
-- [API](#api)
-- [Contribute](#contribute)
-- [License](#license)
+- [IPFS Block Service](#ipfs-block-service)
+  - [Lead Maintainer](#lead-maintainer)
+  - [Table of Contents](#table-of-contents)
+  - [Install](#install)
+    - [npm](#npm)
+  - [Usage](#usage)
+    - [Node.js](#nodejs)
+    - [Example](#example)
+    - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
+    - [Browser: `<script>` Tag](#browser-script-tag)
+  - [API](#api)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## Install
 
@@ -63,7 +66,7 @@ const BlockService = require('ipfs-block-service')
 
 ```js
 const BlockService = require('ipfs-block-service')
-const Block = require('ipfs-block')
+const Block = require('ipld-block')
 const multihashing = require('multihashing-async')
 const IPFSRepo = require('ipfs-repo')  // storage repo
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "cids": "^0.8.0",
     "dirty-chai": "^2.0.1",
     "fs-extra": "^9.0.0",
-    "ipfs-block": "~0.8.1",
-    "ipfs-repo": "^1.0.1",
+    "ipfs-repo": "^2.0.0",
+    "ipld-block": "^0.9.1",
     "lodash": "^4.17.11",
     "multihashing-async": "^0.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cids": "^0.8.0",
     "dirty-chai": "^2.0.1",
     "fs-extra": "^9.0.0",
-    "ipfs-repo": "^2.0.0",
+    "ipfs-repo": "ipfs/js-ipfs-repo#feat/add-deletemany-method",
     "ipld-block": "^0.9.1",
     "lodash": "^4.17.11",
     "multihashing-async": "^0.8.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cids": "^0.8.0",
     "dirty-chai": "^2.0.1",
     "fs-extra": "^9.0.0",
-    "ipfs-repo": "ipfs/js-ipfs-repo#feat/add-deletemany-method",
+    "ipfs-repo": "^2.1.0",
     "ipld-block": "^0.9.1",
     "lodash": "^4.17.11",
     "multihashing-async": "^0.8.1"

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ class BlockService {
   /**
    * Put a multiple blocks to the underlying datastore.
    *
-   * @param {Array<Block>} blocks
+   * @param {AsyncIterator<Block>} blocks
    * @param {Object} [options] -  Options is an object with the following properties
    * @param {AbortSignal} [options.signal] - A signal that can be used to abort any long-lived operations that are started as a result of this operation
    * @returns {Promise}
@@ -102,10 +102,10 @@ class BlockService {
   /**
    * Get multiple blocks back from an array of cids.
    *
-   * @param {Array<CID>} cids
+   * @param {AsyncIterator<CID>} cids
    * @param {Object} [options] -  Options is an object with the following properties
    * @param {AbortSignal} [options.signal] - A signal that can be used to abort any long-lived operations that are started as a result of this operation
-   * @returns {Iterator<Block>}
+   * @returns {AsyncIterator<Block>}
    */
   getMany (cids, options) {
     if (!Array.isArray(cids)) {
@@ -134,6 +134,28 @@ class BlockService {
     }
 
     return this._repo.blocks.delete(cid, options)
+  }
+
+  /**
+   * Delete multiple blocks from the blockstore.
+   *
+   * @param {AsyncIterator<CID>} cids
+   * @param {Object} [options] -  Options is an object with the following properties
+   * @param {AbortSignal} [options.signal] - A signal that can be used to abort any long-lived operations that are started as a result of this operation
+   * @returns {Promise}
+   */
+  deleteMany (cids, options) {
+    const repo = this._repo
+
+    return this._repo.blocks.deleteMany(async function * () {
+      for await (const cid of cids) {
+        if (!await repo.blocks.has(cid)) {
+          throw errcode(new Error('blockstore: block not found'), 'ERR_BLOCK_NOT_FOUND')
+        }
+
+        yield cid
+      }
+    }(), options)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ class BlockService {
   deleteMany (cids, options) {
     const repo = this._repo
 
-    return this._repo.blocks.deleteMany(async function * () {
+    return this._repo.blocks.deleteMany((async function * () {
       for await (const cid of cids) {
         if (!await repo.blocks.has(cid)) {
           throw errcode(new Error('blockstore: block not found'), 'ERR_BLOCK_NOT_FOUND')
@@ -155,7 +155,7 @@ class BlockService {
 
         yield cid
       }
-    }(), options)
+    }()), options)
   }
 }
 

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -91,6 +91,29 @@ module.exports = (repo) => {
           )
       })
 
+      it('deletes lots of blocks', async () => {
+        const data = Buffer.from('Will not live that much')
+
+        const hash = await multihashing(data, 'sha2-256')
+        const b = new Block(data, new CID(hash))
+
+        await bs.put(b)
+        await bs.deleteMany([b.cid])
+        const res = await bs._repo.blocks.has(b.cid)
+        expect(res).to.be.eql(false)
+      })
+
+      it('does not delete a blocks it does not have', async () => {
+        const data = Buffer.from('Will not live that much ' + Date.now())
+        const cid = new CID(await multihashing(data, 'sha2-256'))
+
+        await bs.deleteMany([cid])
+          .then(
+            () => expect.fail('Should have thrown'),
+            (err) => expect(err).to.have.property('code', 'ERR_BLOCK_NOT_FOUND')
+          )
+      })
+
       it('stores and gets lots of blocks', async function () {
         this.timeout(8 * 1000)
 

--- a/test/block-service-test.js
+++ b/test/block-service-test.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 
-const Block = require('ipfs-block')
+const Block = require('ipld-block')
 const _ = require('lodash')
 const { collect } = require('streaming-iterables')
 const CID = require('cids')


### PR DESCRIPTION
Similar to the putMany and getMany methods, deleteMany allows passing streams of CIDs into the module.

Depends on:

- [x] https://github.com/ipfs/js-ipfs-block-service/pull/91
- [x] https://github.com/ipfs/js-ipfs-repo/pull/230