### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ const BlockService = require('ipfs-block-service')
 const Block = require('ipld-block')
 const multihashing = require('multihashing-async')
 const IPFSRepo = require('ipfs-repo')  // storage repo
+const uint8ArrayEquals = require('uint8arrays/equals')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 // setup a repo
 const repo = new IPFSRepo('example')
 
 // create a block
-const data = new Buffer('hello world')
+const data = uint8ArrayFromString('hello world')
 const multihash = await multihashing(data, 'sha2-256')
 
 const cid = new CID(multihash)
@@ -87,7 +89,7 @@ const service = new BlockService(repo)
 await service.put(block)
 
 const result = await service.get(cid)
-console.log(block.data.toString() === result.data.toString())
+console.log(uint8ArrayEquals(block.data, result.data))
 // => true
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,24 +31,23 @@
   "homepage": "https://github.com/ipfs/js-ipfs-block-service#readme",
   "devDependencies": {
     "abort-controller": "^3.0.0",
-    "aegir": "^21.8.1",
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
-    "cids": "^0.8.0",
-    "dirty-chai": "^2.0.1",
+    "aegir": "^22.0.0",
+    "cids": "^1.0.0",
     "fs-extra": "^9.0.0",
-    "ipfs-repo": "^2.1.0",
-    "ipld-block": "^0.9.1",
+    "ipfs-repo": "^6.0.0",
+    "ipld-block": "^0.10.0",
+    "it-drain": "^1.0.1",
     "lodash": "^4.17.11",
-    "multihashing-async": "^0.8.1"
+    "multihashing-async": "^2.0.1",
+    "uint8arrays": "^1.0.0"
   },
   "engines": {
-    "node": ">=6.0.0",
+    "node": ">=12.0.0",
     "npm": ">=3.0.0"
   },
   "dependencies": {
     "err-code": "^2.0.0",
-    "streaming-iterables": "^4.1.0"
+    "streaming-iterables": "^5.0.2"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/test/aborting-requests.spec.js
+++ b/test/aborting-requests.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-chai.use(require('chai-as-promised'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 
 const { collect } = require('streaming-iterables')
 const AbortController = require('abort-controller')


### PR DESCRIPTION
BREAKING CHANGE:

- All uses of Buffers have been replaced with Uint8Arrays
- The ipfs-repo this module uses only returns Uint8Arrays